### PR TITLE
Restructure helpers

### DIFF
--- a/helpers/cubes.py
+++ b/helpers/cubes.py
@@ -3,6 +3,7 @@
 import warnings
 
 import iris
+import numpy as np
 from iris.util import equalise_attributes
 from scriptengine.exceptions import ScriptEngineTaskArgumentInvalidError
 

--- a/helpers/cubes.py
+++ b/helpers/cubes.py
@@ -34,28 +34,21 @@ def load_input_cube(src, varname):
     return leg_cube
 
 
-def set_metadata(cube, title=None, comment=None, **kwargs):
+def set_metadata(cube, **kwargs):
     """Set metadata for diagnostic."""
-    metadata = {
-        "title": title,
-        "comment": comment,
+    defaults = {
         "source": "EC-Earth 4",
         "Conventions": "CF-1.8",
     }
-    for key, value in kwargs.items():
-        metadata[f"{key}"] = value
-
-    metadata_to_discard = [
+    drop = (
         "description",
         "interval_operation",
         "interval_write",
         "name",
         "online_operation",
-    ]
-    for key, value in metadata.items():
-        if value is not None:
-            cube.attributes[key] = value
-    for key in metadata_to_discard:
+    )
+    cube.attributes.update(dict(defaults, **kwargs))
+    for key in drop:
         cube.attributes.pop(key, None)
     return cube
 

--- a/helpers/files.py
+++ b/helpers/files.py
@@ -1,0 +1,19 @@
+"""Helper module for handling files."""
+
+import os
+from pathlib import Path
+
+
+# Using https://stackoverflow.com/revisions/13197763/9
+class ChangeDirectory:
+    """Context manager for changing the current working directory"""
+
+    def __init__(self, new_path):
+        self.new_path = Path(new_path).expanduser()
+        self.saved_path = Path.cwd()
+
+    def __enter__(self):
+        os.chdir(self.new_path)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.saved_path)

--- a/helpers/nemo.py
+++ b/helpers/nemo.py
@@ -1,0 +1,22 @@
+"""Helper module for NEMO data."""
+
+import iris
+
+
+def compute_spatial_weights(domain_src, array_shape, grid):
+    "Compute weights for spatial averaging"
+    domain_cfg = iris.load(domain_src)
+    scale_factors = [
+        domain_cfg.extract(f"e1{grid.lower()}")[0][0],
+        domain_cfg.extract(f"e2{grid.lower()}")[0][0],
+    ]
+    cell_areas = scale_factors[0] * scale_factors[1]
+    cell_weights = np.broadcast_to(cell_areas.data, array_shape)
+    return cell_weights
+
+
+def remove_unique_attributes(cube):
+    # NEMO attributes unique to each file:
+    cube.attributes.pop("uuid", None)
+    cube.attributes.pop("timeStamp", None)
+    return cube

--- a/helpers/nemo.py
+++ b/helpers/nemo.py
@@ -1,6 +1,7 @@
 """Helper module for NEMO data."""
 
 import iris
+import numpy as np
 
 
 def compute_spatial_weights(domain_src, array_shape, grid):

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import yaml
 
 from helpers.exceptions import InvalidMapTypeException, PresentationException
-from helpers.file_handling import ChangeDirectory
+from helpers.files import ChangeDirectory
 from helpers.map_type_handling import function_mapper
 
 

--- a/monitoring/map.py
+++ b/monitoring/map.py
@@ -9,7 +9,7 @@ from scriptengine.exceptions import (
 )
 from scriptengine.tasks.core import Task
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 
 class Map(Task):
@@ -65,7 +65,9 @@ class Map(Task):
         Compute Time Average for the whole simulation.
         """
         self.log_debug("Computing simulation average.")
-        time_weights = helpers.compute_time_weights(merged_cube, merged_cube.shape)
+        time_weights = helpers.cubes.compute_time_weights(
+            merged_cube, merged_cube.shape
+        )
         simulation_avg = merged_cube.collapsed(
             "time",
             iris.analysis.MEAN,

--- a/monitoring/markdown.py
+++ b/monitoring/markdown.py
@@ -7,7 +7,7 @@ from scriptengine.jinja import filters as j2filters
 from scriptengine.tasks.core import Task, timed_runner
 
 from helpers.exceptions import PresentationException
-from helpers.file_handling import ChangeDirectory
+from helpers.files import ChangeDirectory
 from helpers.presentation_objects import PresentationObject
 
 

--- a/monitoring/nemo_all_mean_map.py
+++ b/monitoring/nemo_all_mean_map.py
@@ -3,7 +3,7 @@
 import iris
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .map import Map
 
@@ -31,12 +31,12 @@ class NemoAllMeanMap(Map):
 
         self.check_file_extension(dst)
 
-        leg_cube = helpers.load_input_cube(src, varname)
+        leg_cube = helpers.cubes.load_input_cube(src, varname)
 
         # Remove auxiliary time coordinate before collapsing cube
         leg_cube.remove_coord(leg_cube.coord("time", dim_coords=False))
 
-        time_weights = helpers.compute_time_weights(leg_cube, leg_cube.shape)
+        time_weights = helpers.cubes.compute_time_weights(leg_cube, leg_cube.shape)
         leg_average = leg_cube.collapsed(
             "time", iris.analysis.MEAN, weights=time_weights
         )
@@ -44,7 +44,7 @@ class NemoAllMeanMap(Map):
         leg_average.coord("time").climatological = True
         leg_average = self.set_cell_methods(leg_average)
 
-        leg_average = helpers.set_metadata(
+        leg_average = helpers.cubes.set_metadata(
             leg_average,
             title=f"{leg_average.long_name.title()} (Annual Mean Climatology)",
             comment=f"Simulation Average of **{varname}**.",

--- a/monitoring/nemo_global_mean_year_mean_timeseries.py
+++ b/monitoring/nemo_global_mean_year_mean_timeseries.py
@@ -5,7 +5,8 @@ import warnings
 import iris
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
+import helpers.nemo
 
 from .timeseries import Timeseries
 
@@ -42,7 +43,7 @@ class NemoGlobalMeanYearMeanTimeseries(Timeseries):
 
         self.check_file_extension(dst)
 
-        leg_cube = helpers.load_input_cube(src, varname)
+        leg_cube = helpers.cubes.load_input_cube(src, varname)
 
         grid = self.getarg("grid", context, default="T")
         with warnings.catch_warnings():
@@ -55,7 +56,7 @@ class NemoGlobalMeanYearMeanTimeseries(Timeseries):
             spatial_avg = leg_cube.collapsed(
                 ["latitude", "longitude"],
                 iris.analysis.MEAN,
-                weights=helpers.compute_spatial_weights(
+                weights=helpers.nemo.compute_spatial_weights(
                     domain, leg_cube.shape, grid=grid
                 ),
             )
@@ -64,12 +65,12 @@ class NemoGlobalMeanYearMeanTimeseries(Timeseries):
         ann_spatial_avg = spatial_avg.collapsed(
             "time",
             iris.analysis.MEAN,
-            weights=helpers.compute_time_weights(spatial_avg),
+            weights=helpers.cubes.compute_time_weights(spatial_avg),
         )
         # Promote time from scalar to dimension coordinate
         ann_spatial_avg = iris.util.new_axis(ann_spatial_avg, "time")
 
-        ann_spatial_avg = helpers.set_metadata(
+        ann_spatial_avg = helpers.cubes.set_metadata(
             ann_spatial_avg,
             title=f"{ann_spatial_avg.long_name} (Annual Mean)",
             comment=comment,

--- a/monitoring/nemo_time_mean_temporalmap.py
+++ b/monitoring/nemo_time_mean_temporalmap.py
@@ -3,7 +3,7 @@
 import iris
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .temporalmap import Temporalmap
 
@@ -31,7 +31,7 @@ class NemoTimeMeanTemporalmap(Temporalmap):
 
         self.check_file_extension(dst)
 
-        leg_cube = helpers.load_input_cube(src, varname)
+        leg_cube = helpers.cubes.load_input_cube(src, varname)
 
         # Remove auxiliary time coordinate before collapsing cube
         leg_cube.remove_coord(leg_cube.coord("time", dim_coords=False))
@@ -50,13 +50,13 @@ class NemoYearMeanTemporalmap(NemoTimeMeanTemporalmap):
 
     def time_operation(self, varname, leg_cube):
         self.log_debug("Creating an annual mean.")
-        month_weights = helpers.compute_time_weights(leg_cube, leg_cube.shape)
+        month_weights = helpers.cubes.compute_time_weights(leg_cube, leg_cube.shape)
         leg_average = leg_cube.collapsed(
             "time", iris.analysis.MEAN, weights=month_weights
         )
         # Promote time from scalar to dimension coordinate
         leg_average = iris.util.new_axis(leg_average, "time")
-        leg_average = helpers.set_metadata(
+        leg_average = helpers.cubes.set_metadata(
             leg_average,
             title=f"{leg_average.long_name.title()} (Annual Mean Map)",
             comment=f"Leg Mean of **{varname}**.",
@@ -77,7 +77,7 @@ class NemoMonthMeanTemporalmap(NemoTimeMeanTemporalmap):
 
     def time_operation(self, varname, leg_cube):
         self.log_debug("Creating monthly means.")
-        leg_cube = helpers.set_metadata(
+        leg_cube = helpers.cubes.set_metadata(
             leg_cube,
             title=f"{leg_cube.long_name.title()} (Monthly Mean Map)",
             comment=f"Monthly Mean of **{varname}**.",

--- a/monitoring/oifs_all_mean_map.py
+++ b/monitoring/oifs_all_mean_map.py
@@ -4,7 +4,7 @@ import iris
 from scriptengine.exceptions import ScriptEngineTaskArgumentInvalidError
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .map import Map
 
@@ -32,7 +32,7 @@ class OifsAllMeanMap(Map):
 
         self.check_file_extension(dst)
 
-        oifs_cube = helpers.load_input_cube(src, varname)
+        oifs_cube = helpers.cubes.load_input_cube(src, varname)
 
         map_cube = self.compute_time_mean(oifs_cube)
 
@@ -76,7 +76,7 @@ class OifsAllMeanMap(Map):
         # Prevent float32/float64 concatenation errors
         map_cube.data = map_cube.data.astype("float64")
         # Add File Metadata
-        map_cube = helpers.set_metadata(
+        map_cube = helpers.cubes.set_metadata(
             map_cube,
             title=f"{map_cube.long_name.title()} (Annual Mean Climatology)",
             comment=f"Simulation Average of **{varname}**.",

--- a/monitoring/oifs_global_mean_year_mean_timeseries.py
+++ b/monitoring/oifs_global_mean_year_mean_timeseries.py
@@ -6,7 +6,7 @@ import iris
 import numpy as np
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .timeseries import Timeseries
 
@@ -32,7 +32,7 @@ class OifsGlobalMeanYearMeanTimeseries(Timeseries):
 
         self.check_file_extension(dst)
 
-        oifs_cube = helpers.load_input_cube(src, varname)
+        oifs_cube = helpers.cubes.load_input_cube(src, varname)
 
         time_mean_cube = self.compute_time_mean(oifs_cube)
 
@@ -122,7 +122,7 @@ class OifsGlobalMeanYearMeanTimeseries(Timeseries):
             f"Each data point represents the (spatial and temporal) "
             f"average over one year."
         )
-        timeseries_cube = helpers.set_metadata(
+        timeseries_cube = helpers.cubes.set_metadata(
             timeseries_cube,
             title=f"{timeseries_cube.long_name} (Annual Mean)",
             comment=comment,

--- a/monitoring/oifs_year_mean_temporalmap.py
+++ b/monitoring/oifs_year_mean_temporalmap.py
@@ -3,7 +3,7 @@
 import iris
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .temporalmap import Temporalmap
 
@@ -27,7 +27,7 @@ class OifsYearMeanTemporalmap(Temporalmap):
 
         self.check_file_extension(dst)
 
-        oifs_cube = helpers.load_input_cube(src, varname)
+        oifs_cube = helpers.cubes.load_input_cube(src, varname)
 
         temporalmap_cube = self.compute_time_mean(oifs_cube)
 
@@ -63,7 +63,7 @@ class OifsYearMeanTemporalmap(Temporalmap):
 
     def adjust_metadata(self, temporalmap_cube, varname: str):
         """Do further adjustments to the cube metadata before saving."""
-        temporalmap_cube = helpers.set_metadata(
+        temporalmap_cube = helpers.cubes.set_metadata(
             temporalmap_cube,
             title=f"{temporalmap_cube.long_name.title()} (Annual Mean Map)",
             comment=f"Annual Mean of **{varname}**.",

--- a/monitoring/redmine.py
+++ b/monitoring/redmine.py
@@ -12,7 +12,7 @@ from scriptengine.jinja import filters as j2filters
 from scriptengine.tasks.core import Task, timed_runner
 
 from helpers.exceptions import PresentationException
-from helpers.file_handling import ChangeDirectory
+from helpers.files import ChangeDirectory
 from helpers.presentation_objects import PresentationObject
 
 

--- a/monitoring/si3_hemis_point_month_mean_all_mean_map.py
+++ b/monitoring/si3_hemis_point_month_mean_all_mean_map.py
@@ -8,7 +8,7 @@ import numpy as np
 from scriptengine.exceptions import ScriptEngineTaskArgumentInvalidError
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .map import Map
 
@@ -57,7 +57,7 @@ class Si3HemisPointMonthMeanAllMeanMap(Map):
             raise ScriptEngineTaskArgumentInvalidError()
         self.check_file_extension(dst)
 
-        month_cube = helpers.load_input_cube(src, varname)
+        month_cube = helpers.cubes.load_input_cube(src, varname)
         # Remove auxiliary time coordinate
         month_cube.remove_coord(month_cube.coord("time", dim_coords=False))
         month_cube = month_cube[0]
@@ -78,7 +78,7 @@ class Si3HemisPointMonthMeanAllMeanMap(Map):
 
         month_cube.data = month_cube.data.astype("float64")
         comment = f"Simulation Average of {meta_dict[varname]} / **{varname}** on {hemisphere}ern hemisphere."
-        month_cube = helpers.set_metadata(
+        month_cube = helpers.cubes.set_metadata(
             month_cube,
             title=f"{month_cube.long_name} (Climatology)",
             comment=comment,

--- a/monitoring/si3_hemis_point_month_mean_temporalmap.py
+++ b/monitoring/si3_hemis_point_month_mean_temporalmap.py
@@ -8,7 +8,7 @@ import numpy as np
 from scriptengine.exceptions import ScriptEngineTaskArgumentInvalidError
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 from .temporalmap import Temporalmap
 
@@ -66,7 +66,7 @@ class Si3HemisPointMonthMeanTemporalmap(Temporalmap):
             raise ScriptEngineTaskArgumentInvalidError()
         self.check_file_extension(dst)
 
-        month_cube = helpers.load_input_cube(src, varname)
+        month_cube = helpers.cubes.load_input_cube(src, varname)
         # Remove auxiliary time coordinate
         month_cube.remove_coord(month_cube.coord("time", dim_coords=False))
 
@@ -78,7 +78,7 @@ class Si3HemisPointMonthMeanTemporalmap(Temporalmap):
 
         month_cube.long_name = f"{meta_dict[varname]['long_name']} {hemisphere}"
         comment = f"{meta_dict[varname]['long_name']} / **{varname}** on {hemisphere}ern hemisphere."
-        month_cube = helpers.set_metadata(
+        month_cube = helpers.cubes.set_metadata(
             month_cube,
             title=f"{month_cube.long_name} {self.get_month(time_coord)}",
             comment=comment,

--- a/monitoring/si3_hemis_sum_month_mean_timeseries.py
+++ b/monitoring/si3_hemis_sum_month_mean_timeseries.py
@@ -7,7 +7,8 @@ import iris
 import numpy as np
 from scriptengine.tasks.core import timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
+import helpers.nemo
 
 from .timeseries import Timeseries
 
@@ -81,8 +82,8 @@ class Si3HemisSumMonthMeanTimeseries(Timeseries):
             return
         self.check_file_extension(dst)
 
-        leg_cube = helpers.load_input_cube(src, varname)
-        cell_weights = helpers.compute_spatial_weights(domain, leg_cube.shape, "T")
+        leg_cube = helpers.cubes.load_input_cube(src, varname)
+        cell_weights = helpers.nemo.compute_spatial_weights(domain, leg_cube.shape, "T")
         latitudes = np.broadcast_to(leg_cube.coord("latitude").points, leg_cube.shape)
         if hemisphere == "north":
             leg_cube.data = np.ma.masked_where(latitudes < 0, leg_cube.data)
@@ -115,7 +116,7 @@ class Si3HemisSumMonthMeanTimeseries(Timeseries):
             ),
             "title": f"{long_name} (Seasonal Cycle)",
         }
-        hemispheric_sum = helpers.set_metadata(hemispheric_sum, **metadata)
+        hemispheric_sum = helpers.cubes.set_metadata(hemispheric_sum, **metadata)
         hemispheric_sum = self.set_cell_methods(hemispheric_sum, hemisphere)
         self.save(hemispheric_sum, dst)
 

--- a/monitoring/timeseries.py
+++ b/monitoring/timeseries.py
@@ -11,7 +11,7 @@ from scriptengine.exceptions import (
 )
 from scriptengine.tasks.core import Task, timed_runner
 
-import helpers.file_handling as helpers
+import helpers.cubes
 
 
 class Timeseries(Task):
@@ -72,7 +72,7 @@ class Timeseries(Task):
         )
 
         # set metadata
-        data_cube = helpers.set_metadata(
+        data_cube = helpers.cubes.set_metadata(
             data_cube,
             title=title,
             comment=comment,

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -1,17 +1,20 @@
-"""Tests for helpers/file_handling.py"""
+"""Tests for files and cubes helpers"""
 
 import os
 
 import iris
+import iris.cube
 import numpy as np
 
-import helpers.file_handling as file_handling
+import helpers.cubes
+import helpers.nemo
+from helpers.files import ChangeDirectory
 
 
 def test_change_directory(tmpdir):
     cwd = os.getcwd()
     nwd = tmpdir.mkdir("temp")
-    with file_handling.ChangeDirectory(nwd):
+    with ChangeDirectory(nwd):
         assert os.getcwd() == nwd
     assert os.getcwd() == cwd
 
@@ -25,7 +28,7 @@ def test_compute_spatial_weights(tmpdir):
     result = np.array([[[2]], [[2]], [[2]]])
     shape = result.shape
     assert (
-        file_handling.compute_spatial_weights(domain_path, shape, "T").all()
+        helpers.nemo.compute_spatial_weights(domain_path, shape, "T").all()
         == result.all()
     )
 
@@ -33,7 +36,7 @@ def test_compute_spatial_weights(tmpdir):
 def test_load_input_cube():
     src = "./tests/testdata/tos_nemo_all_mean_map.nc"
     varname = "tos"
-    assert isinstance(file_handling.load_input_cube(src, varname), iris.cube.Cube)
+    assert isinstance(helpers.cubes.load_input_cube(src, varname), iris.cube.Cube)
 
 
 def test_set_metadata():
@@ -45,7 +48,7 @@ def test_set_metadata():
         "name": None,
         "online_operation": None,
     }
-    updated_cube = file_handling.set_metadata(cube)
+    updated_cube = helpers.cubes.set_metadata(cube)
     assert updated_cube.attributes == {"source": "EC-Earth 4", "Conventions": "CF-1.8"}
     new_metadata = {
         "title": "Title",
@@ -55,5 +58,5 @@ def test_set_metadata():
         "Conventions": "CF-1.8",
         "custom": "Custom",
     }
-    updated_cube = file_handling.set_metadata(updated_cube, **new_metadata)
+    updated_cube = helpers.cubes.set_metadata(updated_cube, **new_metadata)
     assert updated_cube.attributes == new_metadata


### PR DESCRIPTION
I would like to make a few changes in preparation for the work on (NEMO) 3d averages and the sea-ice diagnostics. Mostly splitting the helpers in `file_handling.py` into different modules according to what they do. Because they are not all dealing with files. Furthermore, new/changed helpers will probably be needed for the planned work.

In the long run, we should probably try to avoid "helper" modules, which is often just a sign that we don't know where to put the functions or classes. But for now a better structure would be more than enough.