### PR TITLE
Refactor: ImageIO dependency

### DIFF
--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -223,9 +223,8 @@ class TemporalmapLoader(PresentationObjectLoader):
             fig.savefig(png_dir / f"{self.path.stem}-{ts:03}.png", bbox_inches="tight")
             plt.close(fig)
 
-        images = [imageio.imread(file) for file in sorted(png_dir.iterdir())]
-
-        imageio.imwrite(dst_folder / gif_file, images, fps=2)
+        frames = [imageio.imread(file) for file in sorted(png_dir.iterdir())]
+        imageio.imwrite(dst_folder / gif_file, frames, fps=2)
 
         return {
             "title": self.cube.attributes["title"],

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import wrap
 
 import cftime
-import imageio
+import imageio.v2 as imageio
 import iris
 import iris.quickplot as qplt
 import matplotlib.pyplot as plt
@@ -224,7 +224,7 @@ class TemporalmapLoader(PresentationObjectLoader):
             plt.close(fig)
 
         frames = [imageio.imread(png) for png in sorted(png_dir.iterdir())]
-        imageio.mimsave(dst_folder / gif_file, frames, fps=2)
+        imageio.mimwrite(dst_folder / gif_file, frames, fps=2)
 
         return {
             "title": self.cube.attributes["title"],

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from textwrap import wrap
 
 import cftime
-import imageio.v2 as imageio
+import imageio.v3 as imageio
 import iris
 import iris.quickplot as qplt
 import matplotlib.pyplot as plt
@@ -223,8 +223,9 @@ class TemporalmapLoader(PresentationObjectLoader):
             fig.savefig(png_dir / f"{self.path.stem}-{ts:03}.png", bbox_inches="tight")
             plt.close(fig)
 
-        frames = [imageio.imread(png) for png in sorted(png_dir.iterdir())]
-        imageio.mimwrite(dst_folder / gif_file, frames, fps=2)
+        images = [imageio.imread(file) for file in sorted(png_dir.iterdir())]
+
+        imageio.imwrite(dst_folder / gif_file, images, fps=2)
 
         return {
             "title": self.cube.attributes["title"],

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -223,7 +223,7 @@ class TemporalmapLoader(PresentationObjectLoader):
             fig.savefig(png_dir / f"{self.path.stem}-{ts:03}.png", bbox_inches="tight")
             plt.close(fig)
 
-        frames = [imageio.imread(file) for file in sorted(png_dir.iterdir())]
+        frames = [imageio.imread(png) for png in sorted(png_dir.iterdir())]
         imageio.imwrite(dst_folder / gif_file, frames, fps=2)
 
         return {

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         "pyYAML>=5.1",
         "matplotlib>=3.1",
         "numpy>=1.18",
-        "imageio>=2.0",
+        "imageio>=2.16",
         "scitools-iris>=3.1,!=3.2.0,!=3.2.0.post0",
         "cartopy>=0.20",
         "python-redmine",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         "pyYAML>=5.1",
         "matplotlib>=3.1",
         "numpy>=1.18",
-        "imageio>=2.16",
+        "imageio>=2.18",
         "scitools-iris>=3.1,!=3.2.0,!=3.2.0.post0",
         "cartopy>=0.20",
         "python-redmine",


### PR DESCRIPTION
fix #68 

imageio is moving towards v3 and throws deprecation warnings
since v2.16.2.
They introduced a v2 namespace to allow for using the old API in v2.16.0.
Since v2.16.0 does not affect any of our other dependencies
(we dropped Python 3.6 support either way),
I have updated the dependency and the import
as they suggested in the deprecation warning:

"Starting with ImageIO v3 the behavior of this function will
switch to that of iio.v3.imread.
To keep the current behavior (and make this warning dissapear)
use `import imageio.v2 as imageio` [...]."

See changelog of ImageIO for more info:
https://github.com/imageio/imageio/blob/master/CHANGELOG.md