### PR TITLE
Fix HDF5 segfault

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -4,3 +4,4 @@ dependencies:
     - python>=3.7
     - iris>=3.1,!=3.2.0,!=3.2.0.post0
     - cartopy>=0.20
+    - hdf5!=1.12.2


### PR DESCRIPTION
closes #83 once ready.
The problem seems to happen with hdf5 version 1.12.2 and Python 3.7. Unfortunately, it's really difficult to reproduce which _exact_ version of which _exact_ package is causing this, since changing the version of hdf5 always directly affects a lot of other packages – the beauty of Anaconda...

But this branch/PR can be used to try and isolate the issue + hopefully find a fix for it