### PR TITLE
Create the correct anchors for Redmine TOC

### DIFF
--- a/docs/templates/redmine.txt.j2
+++ b/docs/templates/redmine.txt.j2
@@ -12,7 +12,7 @@ h2. Short-links to diagnostic plots below
 
 {% for item in presentation_list -%}
 {% if item["presentation_type"] == "image" -%}
-* "{{item["title"]}}":{{issue_url}}#{{"-".join(item["title"].replace("(","").replace(")","").split())}}
+* "{{item["title"]}}":{{issue_url}}#{{create_anchor(item["title"])}}
 {% endif -%}
 {% endfor %}
 

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -7,7 +7,8 @@ import pytest
 import redminelib
 import redminelib.exceptions
 import scriptengine.exceptions
-from monitoring.redmine import Redmine
+
+from monitoring.redmine import Redmine, sanitize_anchor_name
 
 
 def test_redmine_presentation_list(tmp_path):
@@ -103,3 +104,9 @@ def test_redmine_run(tmp_path):
     with patch.object(redmine_output, "log_debug") as mock:
         redmine_output.run(init)
     mock.assert_called_with("Saving issue.")
+
+
+def test_sanitize_anchor_name():
+    test_string = "Precipitation - Evaporation (Annual Mean Climatology)"
+    redmine_anchor = "Precipitation-Evaporation-Annual-Mean-Climatology"
+    assert sanitize_anchor_name(test_string) == redmine_anchor


### PR DESCRIPTION
Added a function that creates the HTML anchors for presentation objects in the same manner as done by Redmine itself.
See #80 for a discussion of the issue.

Proposed solution: The function is passed to the Redmine template, which can (but does not have to) use it to add a table of contents (TOC)

Additionally added a test that checks if the function works as expected. I tried to be verbose in the documentation because Regex syntax is powerful but not at all intuitive!

Additional changes come from black/isort