### PR TITLE
Use bash -el {0} when using conda environment

### DIFF
--- a/.github/workflows/install-from-source.yml
+++ b/.github/workflows/install-from-source.yml
@@ -10,7 +10,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    defaults:
+      run:
+        shell: bash -el {0}
+
     steps:
       -
         name: Checkout

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]
@@ -96,7 +96,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
 
     steps:
       -


### PR DESCRIPTION
see discussion in #88.
- bash environment was not properly loaded in publish-to-pypi.yml
- replaced -l with -el since that is now recommended for setup-miniconda