### PR TITLE
change units for precipitation, evaporation and P-E to mm/day

### DIFF
--- a/helpers/cubes.py
+++ b/helpers/cubes.py
@@ -35,6 +35,34 @@ def load_input_cube(src, varname):
     return leg_cube
 
 
+DEFAULT_UNIT_CONVERSIONS = {
+    "kelvin": "degC",
+    "meter^-2-kilogram-second^-1": "meter^-2-kilogram-day^-1",
+}
+
+
+def convert_units(cube: iris.cube.Cube, conversions=None) -> iris.cube.Cube:
+    """Converts units of an Iris cube
+
+    Converts units if the current unit is present in the 'conversions' dict.
+    Does nothing otherwise.
+
+    Args:
+        cube: An Iris cube
+        conversions: A mapping (dict) with 'unit': 'converted_unit' strings.
+          If None (default), then DEFAULT_UNIT_CONVERSIONS (defined above) is used.
+    Returns:
+        An Iris cube with modified units.
+    """
+    if conversions is None:
+        conversions = DEFAULT_UNIT_CONVERSIONS
+    try:
+        cube.convert_units(conversions[cube.units.name])
+    except KeyError:
+        pass
+    return cube
+
+
 def set_metadata(cube, **kwargs):
     """Set metadata for diagnostic."""
     defaults = {

--- a/monitoring/oifs_all_mean_map.py
+++ b/monitoring/oifs_all_mean_map.py
@@ -1,4 +1,5 @@
 """Processing Task that creates a 2D map of a given extensive atmosphere quantity."""
+
 from pathlib import Path
 
 import iris
@@ -82,10 +83,4 @@ class OifsAllMeanMap(Map):
             comment=f"Simulation average of **{varname}**.",
             map_type="global atmosphere",
         )
-        # Convert unit to °C if varname is given in K
-        if map_cube.units.name == "kelvin":
-            map_cube.convert_units("degC")
-        # Convert unit to mm/day if varname is given in kg m-2 s-1
-        if map_cube.units.name == "meter^-2-kilogram-second^-1":
-            map_cube.convert_units("meter^-2-kilogram-day^-1")
-        return map_cube
+        return helpers.cubes.convert_units(map_cube)

--- a/monitoring/oifs_all_mean_map.py
+++ b/monitoring/oifs_all_mean_map.py
@@ -85,4 +85,7 @@ class OifsAllMeanMap(Map):
         # Convert unit to °C if varname is given in K
         if map_cube.units.name == "kelvin":
             map_cube.convert_units("degC")
+        # Convert unit to mm/day if varname is given in kg m-2 s-1
+        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
+            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
         return map_cube

--- a/monitoring/oifs_all_mean_map.py
+++ b/monitoring/oifs_all_mean_map.py
@@ -86,6 +86,6 @@ class OifsAllMeanMap(Map):
         if map_cube.units.name == "kelvin":
             map_cube.convert_units("degC")
         # Convert unit to mm/day if varname is given in kg m-2 s-1
-        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
-            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
+        if map_cube.units.name == "meter^-2-kilogram-second^-1":
+            map_cube.convert_units("meter^-2-kilogram-day^-1")
         return map_cube

--- a/monitoring/oifs_global_mean_year_mean_timeseries.py
+++ b/monitoring/oifs_global_mean_year_mean_timeseries.py
@@ -128,10 +128,4 @@ class OifsGlobalMeanYearMeanTimeseries(Timeseries):
             title=f"{timeseries_cube.long_name} (annual mean)",
             comment=comment,
         )
-        # Convert unit to °C if varname is given in K
-        if timeseries_cube.units.name == "kelvin":
-            timeseries_cube.convert_units("degC")
-        # Convert unit to mm/day if varname is given in kg m-2 s-1
-        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
-            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
-        return timeseries_cube
+        return helpers.cubes.convert_units(timeseries_cube)

--- a/monitoring/oifs_global_mean_year_mean_timeseries.py
+++ b/monitoring/oifs_global_mean_year_mean_timeseries.py
@@ -131,4 +131,7 @@ class OifsGlobalMeanYearMeanTimeseries(Timeseries):
         # Convert unit to °C if varname is given in K
         if timeseries_cube.units.name == "kelvin":
             timeseries_cube.convert_units("degC")
+        # Convert unit to mm/day if varname is given in kg m-2 s-1
+        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
+            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
         return timeseries_cube

--- a/monitoring/oifs_year_mean_temporalmap.py
+++ b/monitoring/oifs_year_mean_temporalmap.py
@@ -71,10 +71,4 @@ class OifsYearMeanTemporalmap(Temporalmap):
             comment=f"Annual mean of **{varname}**.",
             map_type="global atmosphere",
         )
-        # Convert unit to °C if varname is given in K
-        if temporalmap_cube.units.name == "kelvin":
-            temporalmap_cube.convert_units("degC")
-        # Convert unit to mm/day if varname is given in kg m-2 s-1
-        if temporalmap_cube.units.name == "meter^-2-kilogram-second^-1":
-            temporalmap_cube.convert_units("meter^-2-kilogram-day^-1")
-        return temporalmap_cube
+        return helpers.cubes.convert_units(temporalmap_cube)

--- a/monitoring/oifs_year_mean_temporalmap.py
+++ b/monitoring/oifs_year_mean_temporalmap.py
@@ -75,6 +75,6 @@ class OifsYearMeanTemporalmap(Temporalmap):
         if temporalmap_cube.units.name == "kelvin":
             temporalmap_cube.convert_units("degC")
         # Convert unit to mm/day if varname is given in kg m-2 s-1
-        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
-            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
+        if temporalmap_cube.units.name == "meter^-2-kilogram-second^-1":
+            temporalmap_cube.convert_units("meter^-2-kilogram-day^-1")
         return temporalmap_cube

--- a/monitoring/oifs_year_mean_temporalmap.py
+++ b/monitoring/oifs_year_mean_temporalmap.py
@@ -74,4 +74,7 @@ class OifsYearMeanTemporalmap(Temporalmap):
         # Convert unit to °C if varname is given in K
         if temporalmap_cube.units.name == "kelvin":
             temporalmap_cube.convert_units("degC")
+        # Convert unit to mm/day if varname is given in kg m-2 s-1
+        if timeseries_cube.units.name == "meter^-2-kilogram-second^-1":
+            timeseries_cube.convert_units("meter^-2-kilogram-day^-1")
         return temporalmap_cube

--- a/tests/test_cubes.py
+++ b/tests/test_cubes.py
@@ -120,3 +120,17 @@ def test_annual_time_bounds():
         ]
     )
     assert (new_bounds == annual_bounds).all()
+
+
+@pytest.mark.parametrize(
+    ("unit", "converted_unit"),
+    (
+        ("m", "m"),
+        ("m-s^-1", "m-s^-1"),
+        ("kelvin", "degC"),
+        ("meter^-2-kilogram-second^-1", "meter^-2-kilogram-day^-1"),
+    ),
+)
+def test_unit_conversions(unit, converted_unit):
+    cube = Cube(np.array([1]), units=unit)
+    assert helpers.cubes.convert_units(cube).units == cf_units.Unit(converted_unit)


### PR DESCRIPTION
Precipitation and evaporation are often expressed in mm/day (e.g. in ECmean4). It would be nice if the monitoring tool would do the same. This PR does the conversion to give the correct number yet the units are kg m-2 day-1 (which is equivalent to mm/day for water.)

Pinging @uwefladrich @valentinaschueller @jhardenberg @oloapinivad