### PR TITLE
Show optional reference value in timeseries plots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Fixes
 Features
 --------
 - Convert cubes with unit kg m-2 s-1 to kg m-2 day-1 (PR #99)
+- Show optional reference value in timeseries plots (PR #100)
 
 Internal changes
 ----------------

--- a/docs/sphinx/source/tasks/monitoring/presentation-tasks.rst
+++ b/docs/sphinx/source/tasks/monitoring/presentation-tasks.rst
@@ -58,7 +58,7 @@ Example::
                 label: "ERA5 (1991-2020)"
             - path: "{{mondir}}/pr_nemo_global_mean_year_mean_timeseries.nc"
               reference: {"value":2.93, "label":"ERA5 (1991-2020)"}
-            dst: "{{mondir}}/report"
+        dst: "{{mondir}}/report"
         template: "scriptengine-tasks-ecearth/docs/templates/markdown_template.md.j2"
 
 

--- a/docs/sphinx/source/tasks/monitoring/presentation-tasks.rst
+++ b/docs/sphinx/source/tasks/monitoring/presentation-tasks.rst
@@ -38,6 +38,7 @@ Currently, the following customization features are implemented:
 
 * ``value_range``: set the minimum and maximum value of a time series or (temporal) map. Particularly useful for temporal maps. Default: ``[None, None]``
 * ``colormap``: set a custom colormap for maps and temporal maps. Default: ``RdBu_r``. The list of possible colormaps is in the `Matplotlib documentation`_.
+* ``reference``: provide a dict with keys ``value`` and optionally ``label`` for a reference value to be shown in the time series. Default: ``None``. 
 
 Example::
 
@@ -51,7 +52,13 @@ Example::
             - path: "{{mondir}}/tos_nemo_year_mean_temporalmap.nc"
               value_range: [-2, 30]
               colormap: 'viridis'
-        dst: "{{mondir}}/report"
+            - path: "{{mondir}}/tas_nemo_global_mean_year_mean_timeseries.nc"
+              reference:
+                value: 14.4
+                label: "ERA5 (1991-2020)"
+            - path: "{{mondir}}/pr_nemo_global_mean_year_mean_timeseries.nc"
+              reference: {"value":2.93, "label":"ERA5 (1991-2020)"}
+            dst: "{{mondir}}/report"
         template: "scriptengine-tasks-ecearth/docs/templates/markdown_template.md.j2"
 
 

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -98,6 +98,15 @@ class TimeseriesLoader(PresentationObjectLoader):
 
         fig = plt.figure(figsize=(6, 4), dpi=150)
         ax = fig.add_subplot(1, 1, 1)
+
+        # show a (constant) reference value if it is defined
+        reference = kwargs.get("reference", None)
+        if reference:
+            ref_value = reference['value']
+            ref_label = reference['label']
+            ax.plot([coord_points[0],coord_points[-1]],[ref_value,ref_value],
+                    color="r",linestyle="dotted", label=ref_label)
+
         ax.plot(coord_points, self.cube.data, color="k")
         plt.setp(ax.spines.values(), color="grey")
         ax.grid()
@@ -119,6 +128,10 @@ class TimeseriesLoader(PresentationObjectLoader):
         ax.set_ylabel(format_label(self.cube.long_name, self.cube.units))
 
         plt.tight_layout()
+
+        if reference:
+            plt.legend()
+
         with ChangeDirectory(dst_folder):
             fig.savefig(dst_file, bbox_inches="tight")
             plt.close(fig)

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -101,12 +101,18 @@ class TimeseriesLoader(PresentationObjectLoader):
 
         # plot (constant) reference value if defined
         ref = kwargs.get("reference", None)
-        if isinstance(ref,dict):
+        if isinstance(ref, dict):
             ref_value = ref.get("value", None)
             if ref_value:
                 ref_label = ref.get("label", "Reference value")
-                ax.axhline(y=ref_value,xmin=.05,xmax=.95,
-                        color="r",linestyle=":", label=ref_label)
+                ax.axhline(
+                    y=ref_value,
+                    xmin=0.05,
+                    xmax=0.95,
+                    color="r",
+                    linestyle=":",
+                    label=ref_label,
+                )
                 ax.legend()
 
         ax.plot(coord_points, self.cube.data, color="k")

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -101,7 +101,7 @@ class TimeseriesLoader(PresentationObjectLoader):
 
         # plot (constant) reference value if defined
         ref = kwargs.get("reference", None)
-        if ref:
+        if isinstance(ref,dict):
             ref_value = ref.get("value", None)
             if ref_value:
                 ref_label = ref.get("label", "Reference value")

--- a/helpers/presentation_objects.py
+++ b/helpers/presentation_objects.py
@@ -99,13 +99,15 @@ class TimeseriesLoader(PresentationObjectLoader):
         fig = plt.figure(figsize=(6, 4), dpi=150)
         ax = fig.add_subplot(1, 1, 1)
 
-        # show a (constant) reference value if it is defined
-        reference = kwargs.get("reference", None)
-        if reference:
-            ref_value = reference['value']
-            ref_label = reference['label']
-            ax.plot([coord_points[0],coord_points[-1]],[ref_value,ref_value],
-                    color="r",linestyle="dotted", label=ref_label)
+        # plot (constant) reference value if defined
+        ref = kwargs.get("reference", None)
+        if ref:
+            ref_value = ref.get("value", None)
+            if ref_value:
+                ref_label = ref.get("label", "Reference value")
+                ax.axhline(y=ref_value,xmin=.05,xmax=.95,
+                        color="r",linestyle=":", label=ref_label)
+                ax.legend()
 
         ax.plot(coord_points, self.cube.data, color="k")
         plt.setp(ax.spines.values(), color="grey")
@@ -128,10 +130,6 @@ class TimeseriesLoader(PresentationObjectLoader):
         ax.set_ylabel(format_label(self.cube.long_name, self.cube.units))
 
         plt.tight_layout()
-
-        if reference:
-            plt.legend()
-
         with ChangeDirectory(dst_folder):
             fig.savefig(dst_file, bbox_inches="tight")
             plt.close(fig)


### PR DESCRIPTION
For some of the timeseries plots it would be nice to have a reference value to compare to, e.g.

![tas_oifs_global_mean_year_mean_timeseries](https://github.com/user-attachments/assets/5a56fd22-1d7f-4964-9824-e4c6662a3a3c)

The code changes introduced here look for  an optional argument ``reference`` from the diag_list in the monitor.yml file:
````
    - base.context:
        experiment:
          monitoring:
            diag_list:
              - path: "{{experiment.monitoring.diagnostics}}/tas_oifs_global_mean_year_mean_timeseries.nc"
                reference:
                  value: 12.75
                  label: "CRU pre-industrial"
              - "{{experiment.monitoring.diagnostics}}/pr_oifs_global_mean_year_mean_timeseries.nc"
````
In this example the tas timeseries plot shows a reference temperature of 12.75 that supposedly comes from CRU (see plot above). If ``reference`` is missing in a diag_list item, the plot looks just as before, no extra line, no label.

I think this is pretty useful, but to work it requires also that somebody adds proper references to monitor.yml
 
Pinging @uwefladrich @valentinaschueller @jhardenberg