### PR TITLE
Add missing iris.cube import in helpers/cubes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Next Release
 ============
 
+Fixes
+-----
+- Add missing iris.cube import in helpers/cubes (PR #102)
+
 Features
 --------
 - Convert cubes with unit kg m-2 s-1 to kg m-2 day-1 (PR #99)

--- a/helpers/cubes.py
+++ b/helpers/cubes.py
@@ -3,6 +3,7 @@
 import warnings
 
 import iris
+import iris.cube
 import numpy as np
 from iris.util import equalise_attributes
 from scriptengine.exceptions import ScriptEngineTaskArgumentInvalidError


### PR DESCRIPTION
See #101 and [this comment](https://github.com/uwefladrich/scriptengine-tasks-ecearth/pull/99#discussion_r1812950842). The type hint references `iris.cube.Cube`, which needs an import of `iris.cube`.