### PR TITLE
Temporary pin `dask!=2025.4` to avoid Iris saver issue

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -6,4 +6,4 @@ dependencies:
     - iris>=3.5
     - cartopy>=0.20
     - hdf5!=1.12.2
-    - dask!=2025.4
+    - dask-core!=2025.4.0,!=2025.4.1

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -6,3 +6,4 @@ dependencies:
     - iris>=3.5
     - cartopy>=0.20
     - hdf5!=1.12.2
+    - dask!=2025.4


### PR DESCRIPTION
same temporary solution as in ESMValTool until the issue is solved in Iris: https://github.com/ESMValGroup/ESMValCore/pull/2717

This should close #114 